### PR TITLE
improve swagger api doc for map data

### DIFF
--- a/definition_builder.go
+++ b/definition_builder.go
@@ -203,8 +203,10 @@ func (b definitionBuilder) buildProperty(field reflect.StructField, model *spec.
 		stringt := "string"
 		prop.Type = []string{stringt}
 		return jsonName, modelDescription, prop
-	case fieldKind == reflect.Map, fieldKind == reflect.Interface:
-		// if it's a map, it's unstructured, and swagger can't handle it
+	case fieldKind == reflect.Map:
+		jsonName, prop := b.buildMapTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Interface:
 		objectType := "object"
 		prop.Type = []string{objectType}
 		return jsonName, modelDescription, prop
@@ -370,6 +372,38 @@ func (b definitionBuilder) buildPointerTypeProperty(field reflect.StructField, j
 			prop.Ref = spec.MustCreateRef("#/definitions/" + elemName)
 		}
 		b.addModel(fieldType.Elem(), elemName)
+	}
+	return jsonName, prop
+}
+
+func (b definitionBuilder) buildMapTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop spec.Schema) {
+	setPropertyMetadata(&prop, field)
+	fieldType := field.Type
+	var pType = "object"
+	prop.Type = []string{pType}
+
+	// As long as the element isn't an interface, we should be able to figure out what the
+	// intended type is and represent it in `AdditionalProperties`.
+	// See: https://swagger.io/docs/specification/data-models/dictionaries/
+	if fieldType.Elem().Kind().String() != "interface" {
+		isPrimitive := b.isPrimitiveType(fieldType.Elem().Name())
+		elemTypeName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
+		prop.AdditionalProperties = &spec.SchemaOrBool{
+			Schema: &spec.Schema{},
+		}
+		if isPrimitive {
+			mapped := b.jsonSchemaType(elemTypeName)
+			prop.AdditionalProperties.Schema.Type = []string{mapped}
+		} else {
+			prop.AdditionalProperties.Schema.Ref = spec.MustCreateRef("#/definitions/" + elemTypeName)
+		}
+		// add|overwrite model for element type
+		if fieldType.Elem().Kind() == reflect.Ptr {
+			fieldType = fieldType.Elem()
+		}
+		if !isPrimitive {
+			b.addModel(fieldType.Elem(), elemTypeName)
+		}
 	}
 	return jsonName, prop
 }


### PR DESCRIPTION
@dexyk this improves the structure for model data, like 

```
[
  {
    "BIID": "string",
    "add": {
      "additionalProp1": {
        "expiryTime": "2019-02-21T02:53:43.910Z",
        "value": {}
      },
      "additionalProp2": {
        "expiryTime": "2019-02-21T02:53:43.910Z",
        "value": {}
      },
      "additionalProp3": {
        "expiryTime": "2019-02-21T02:53:43.910Z",
        "value": {}
      }
    },
    "class": "string",
    "remove": {
      "additionalProp1": {
        "expiryTime": "2019-02-21T02:53:43.911Z",
        "value": {}
      },
      "additionalProp2": {
        "expiryTime": "2019-02-21T02:53:43.911Z",
        "value": {}
      },
      "additionalProp3": {
        "expiryTime": "2019-02-21T02:53:43.911Z",
        "value": {}
      }
    }
  }
]
```